### PR TITLE
Add Vercel grade checking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# DLUT-grade-fetch
+# DLUT Grade Checker
+
+这是一个可部署到 Vercel 的成绩查询工具。用户输入 `idToken` 和 `SERVERNAME` 后，页面会通过 Vercel Serverless Function 代理请求教务系统接口并展示课程成绩。
+
+## 部署
+
+1. 将代码推送到 GitHub 并在 Vercel 上新建项目。
+2. 默认配置即可完成部署，静态文件位于 `public/`，函数位于 `api/`。
+
+## 使用
+
+打开部署后的页面，输入从教务系统获得的 `idToken` 以及 `SERVERNAME`（如 `c4`），点击“获取成绩”即可在页面查看成绩并可下载完整 JSON 数据。
+
+请注意保护好个人 `idToken`，本工具不保存任何输入信息。

--- a/api/grades.js
+++ b/api/grades.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  const { idToken, serverName } = req.method === 'POST' ? req.body : req.query;
+
+  if (!idToken || !serverName) {
+    return res.status(400).json({ error: 'Missing idToken or serverName' });
+  }
+
+  const targetUrl = 'http://jxgl.dlut.edu.cn/eams-micro-server/api/v1/grade/student/grades';
+
+  const headers = {
+    'Accept': 'application/json',
+    'X-Id-Token': idToken,
+    'Referer': `http://jxgl.dlut.edu.cn/eams-student-grade-app/index.html?idToken=${idToken}`,
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+    'Cookie': `SERVERNAME=${serverName}; userToken=${idToken}`
+  };
+
+  try {
+    const response = await fetch(targetUrl, { headers });
+    const text = await response.text();
+    res.status(response.status).send(text);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch grades', detail: err.message });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dlut-grade-checker",
+  "version": "1.0.0",
+  "description": "Vercel web app to fetch DLUT grades via idToken",
+  "type": "module",
+  "engines": {
+    "node": "18.x"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DLUT 成绩查询工具</title>
+  <link rel="stylesheet" href="https://unpkg.com/picocss@1.5.9/dist/pico.min.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container">
+    <h1>成绩查询</h1>
+    <p>输入 <strong>idToken</strong> 与 <strong>SERVERNAME</strong> 后点击“获取成绩”。请注意，idToken 含有敏感信息，仅在可信环境使用。</p>
+
+    <form id="grade-form">
+      <label for="idToken">idToken</label>
+      <input type="text" id="idToken" placeholder="请输入您的 idToken" required>
+
+      <label for="serverName">SERVERNAME</label>
+      <input type="text" id="serverName" placeholder="如 c4 或 c8" required>
+
+      <button type="submit" id="fetch-btn">获取成绩</button>
+    </form>
+
+    <div id="status" role="alert"></div>
+
+    <table id="grades-table" hidden>
+      <thead>
+        <tr>
+          <th>课程名称</th>
+          <th>平时成绩</th>
+          <th>期末成绩</th>
+          <th>最终成绩</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <button id="download-btn" hidden>下载完整成绩数据 (JSON)</button>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,74 @@
+const form = document.getElementById('grade-form');
+const statusEl = document.getElementById('status');
+const table = document.getElementById('grades-table');
+const tbody = table.querySelector('tbody');
+const downloadBtn = document.getElementById('download-btn');
+let lastData = null;
+
+function extractScore(subGrades, type) {
+  const item = (subGrades || []).find(s => s.subGradeType && s.subGradeType.nameZh === type);
+  return item ? item.result : null;
+}
+
+function parseFromDetail(detail, key) {
+  if (!detail) return null;
+  const regex = new RegExp(`${key}[:：]\\s*(\\d+(?:\\.\\d+)?)`);
+  const match = detail.match(regex);
+  return match ? match[1] : null;
+}
+
+function renderTable(data) {
+  tbody.innerHTML = '';
+  data.forEach(course => {
+    const row = document.createElement('tr');
+    const pingshi = extractScore(course.subGrades, '平时成绩') || parseFromDetail(course.gradeDetail, '平时成绩') || 'N/A';
+    const qimo = extractScore(course.subGrades, '期末成绩') || parseFromDetail(course.gradeDetail, '期末成绩') || 'N/A';
+    const final = course.finalGrade ?? 'N/A';
+
+    row.innerHTML = `
+      <td>${course.courseNameZh || '未知课程'}</td>
+      <td>${pingshi}</td>
+      <td>${qimo}</td>
+      <td>${final}</td>
+    `;
+    tbody.appendChild(row);
+  });
+  table.hidden = false;
+  downloadBtn.hidden = false;
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const idToken = document.getElementById('idToken').value.trim();
+  const serverName = document.getElementById('serverName').value.trim();
+
+  statusEl.textContent = '正在获取成绩...';
+  table.hidden = true;
+  downloadBtn.hidden = true;
+
+  try {
+    const res = await fetch(`/api/grades?idToken=${encodeURIComponent(idToken)}&serverName=${encodeURIComponent(serverName)}`);
+    const data = await res.json();
+    if (!res.ok || data.result !== 0) {
+      const msg = data.message || '请求失败';
+      statusEl.textContent = `获取失败：${msg}`;
+      return;
+    }
+    statusEl.textContent = '获取成功';
+    lastData = data;
+    renderTable(data.data || []);
+  } catch (err) {
+    statusEl.textContent = `发生错误：${err.message}`;
+  }
+});
+
+downloadBtn.addEventListener('click', () => {
+  if (!lastData) return;
+  const blob = new Blob([JSON.stringify(lastData, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'grades_data.json';
+  a.click();
+  URL.revokeObjectURL(url);
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,27 @@
+:root {
+  --primary: #DA7756;
+  --background: #EEECE2;
+}
+
+body {
+  background-color: var(--background);
+  font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+}
+
+h1, h2 {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+button,
+input {
+  border-radius: 4px;
+}
+
+#grades-table {
+  margin-top: 1rem;
+}
+
+#status {
+  margin-top: 1rem;
+  color: var(--primary);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/", "destination": "/public/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add serverless function to proxy grade API
- create web UI for entering `idToken` and `SERVERNAME`
- allow downloading original JSON
- add basic styles
- document deployment instructions

## Testing
- `node --version`
- `node -e "import('./api/grades.js').then(m=>console.log(typeof m.default))"`


------
https://chatgpt.com/codex/tasks/task_e_6847c7b7bbf8832db4316bcd98d96561