### PR TITLE
调整前端布局并默认使用 c4 服务器

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DLUT Grade Checker
 
-这是一个可部署到 Vercel 的成绩查询工具。用户输入 `idToken` 和 `SERVERNAME` 后，页面会通过 Vercel Serverless Function 代理请求教务系统接口并展示课程成绩。
+这是一个可部署到 Vercel 的成绩查询工具。用户输入 `idToken` 后，页面会通过 Vercel Serverless Function 代理请求教务系统接口并展示课程成绩，内部固定使用 `c4` 服务器。
 
 ## 部署
 
@@ -9,6 +9,6 @@
 
 ## 使用
 
-打开部署后的页面，输入从教务系统获得的 `idToken` 以及 `SERVERNAME`（如 `c4`），点击“获取成绩”即可在页面查看成绩并可下载完整 JSON 数据。
+打开部署后的页面，输入从教务系统获得的 `idToken`，点击“获取成绩”即可在页面查看成绩并可下载完整 JSON 数据，服务器名称已固定为 `c4`。
 
 请注意保护好个人 `idToken`，本工具不保存任何输入信息。

--- a/public/index.html
+++ b/public/index.html
@@ -10,14 +10,13 @@
 <body>
   <main class="container">
     <h1>成绩查询</h1>
-    <p>输入 <strong>idToken</strong> 与 <strong>SERVERNAME</strong> 后点击“获取成绩”。请注意，idToken 含有敏感信息，仅在可信环境使用。</p>
+    <p>输入 <strong>idToken</strong> 后点击“获取成绩”。页面将自动使用 <code>c4</code> 服务器。请注意，idToken 含有敏感信息，仅在可信环境使用。</p>
+
+    <button id="download-btn" hidden>下载完整成绩数据 (JSON)</button>
 
     <form id="grade-form">
       <label for="idToken">idToken</label>
       <input type="text" id="idToken" placeholder="请输入您的 idToken" required>
-
-      <label for="serverName">SERVERNAME</label>
-      <input type="text" id="serverName" placeholder="如 c4 或 c8" required>
 
       <button type="submit" id="fetch-btn">获取成绩</button>
     </form>
@@ -36,7 +35,6 @@
       <tbody></tbody>
     </table>
 
-    <button id="download-btn" hidden>下载完整成绩数据 (JSON)</button>
   </main>
 
   <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -40,7 +40,7 @@ function renderTable(data) {
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const idToken = document.getElementById('idToken').value.trim();
-  const serverName = document.getElementById('serverName').value.trim();
+  const serverName = 'c4';
 
   statusEl.textContent = '正在获取成绩...';
   table.hidden = true;

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,15 +6,32 @@
 body {
   background-color: var(--background);
   font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  padding: 2rem 0;
 }
 
 h1, h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  margin-bottom: 1rem;
 }
 
 button,
 input {
   border-radius: 4px;
+}
+
+button {
+  background-color: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+td {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.container {
+  max-width: 600px;
+  margin: auto;
 }
 
 #grades-table {


### PR DESCRIPTION
## Summary
- set server name to `c4` automatically
- move the JSON download button above the form
- tweak fonts and layout to follow warm, minimal style
- update README to reflect fixed server name

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847cb98c0fc832db1f5ef6d2ccc8039